### PR TITLE
Fix two links in main README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ The Dose Response Curve was recreated. See [this vignette][5] for the source cod
 [2]: https://github.com/csdaw/ggprism/
 [3]: https://pwwang.github.io/plotnine-prism
 [4]: https://pwwang.github.io/plotnine-prism/raw/get_started/
-[5]: https://pwwang.github.io/plotnine-prism/raw/ex1-dose
+[5]: https://pwwang.github.io/plotnine-prism/raw/ex1-dose/
 [6]: https://nbviewer.org/github/pwwang/plotnine-prism/blob/master/examples/README.ipynb
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Dose Response Curve was recreated. See [this vignette][5] for the source cod
 [1]: https://github.com/has2k1/plotnine
 [2]: https://github.com/csdaw/ggprism/
 [3]: https://pwwang.github.io/plotnine-prism
-[4]: https://pwwang.github.io/plotnine-prism/get_started
+[4]: https://pwwang.github.io/plotnine-prism/raw/get_started/
 [5]: https://pwwang.github.io/plotnine-prism/raw/ex1-dose
-[6]: https://pwwang.github.io/plotnine-prism/raw/README
+[6]: https://nbviewer.org/github/pwwang/plotnine-prism/blob/master/examples/README.ipynb
 


### PR DESCRIPTION
Two links in the main READMe, and the documentation, derived from that currently don't work.
This should fix.